### PR TITLE
refactor(services): Extraer la lógica para obtener las categorías de …

### DIFF
--- a/src/components/FoodDetailsModal.jsx
+++ b/src/components/FoodDetailsModal.jsx
@@ -18,8 +18,8 @@ const FoodDetailsModal = ({ combo, onClose }) => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    getAdditionals(setAdditionals, combo.category_id);
-  }, [combo.id]);
+    getAdditionals(setAdditionals, combo.shop.id);
+  }, [combo.shop.id]);
 
   // bloquear scroll body cuando la modal está abierta
   useEffect(() => {

--- a/src/services/getAdditionals.js
+++ b/src/services/getAdditionals.js
@@ -1,11 +1,8 @@
 import api from '../lib/api';
 
-const getAdditionals = async (setAdditionals, category_id) => {
+const getAdditionals = async (setAdditionals, shop_id) => {
   try {
-    const response = await api.get(
-      `/api/products/adiciones?category_id=${category_id}`
-    );
-
+    const response = await api.get(`/products/additions?shop_id=${shop_id}`);
     if (response.status === 200) {
       const additionals = response.data;
       setAdditionals(additionals);

--- a/src/services/getShopCategories.js
+++ b/src/services/getShopCategories.js
@@ -1,0 +1,14 @@
+import api from '../lib/api';
+
+const getShopCategories = async (setCategories, shop_id, hideLoader) => {
+  try {
+    const response = await api.get(`/products?shop_id=${shop_id}`);
+    if (response.status === 200) {
+      setCategories(response.data);
+    }
+  } finally {
+    hideLoader();
+  }
+};
+
+export default getShopCategories;

--- a/src/services/getShopDetails.js
+++ b/src/services/getShopDetails.js
@@ -1,5 +1,6 @@
 import api from '../lib/api';
 import useLoaderStore from '../store/loaderStore';
+import getShopCategories from './getShopCategories';
 
 const getShopDetails = async (setShop, setCategories, tag_shop) => {
   const { showLoader, hideLoader } = useLoaderStore.getState();
@@ -7,13 +8,13 @@ const getShopDetails = async (setShop, setCategories, tag_shop) => {
   try {
     const response = await api.get(`/api/shops?tag=${tag_shop}`);
     if (response.status === 200) {
-      const data = response.data;
+      const data = response.data[0];
       setShop(data);
-      setCategories(data.categories);
+      getShopCategories(setCategories, data.id, hideLoader);
       return;
     }
   } finally {
-    hideLoader();
+    return;
   }
 };
 


### PR DESCRIPTION
…la tienda

Se ha extraído la lógica para obtener las categorías de una tienda desde el servicio `getShopDetails` a su propio archivo de servicio `getShopCategories.js`.

Este cambio mejora la modularidad y la separación de responsabilidades, permitiendo que cada servicio tenga un único propósito. `getShopDetails` ahora se enfoca solo en obtener los detalles de la tienda y delega la obtención de las categorías al nuevo servicio.