### PR TITLE
feat(products): Implementar selección de sabores en el modal de detalles

### DIFF
--- a/src/components/CheckoutShopping.jsx
+++ b/src/components/CheckoutShopping.jsx
@@ -222,15 +222,15 @@ const CheckoutShopping = () => {
             formatNumber
         );
 
-        const phone = placeOrder.shopInfo.phone;
+        const phone = placeOrder.shopInfo.home_phone;
         // Limpia solo productos de la tienda actual
         if (placeOrder?.shopId) removeShopItems(placeOrder.shopId);
 
         sendOrders(Orders)
-        /* clearPlaceOrder();
+        clearPlaceOrder();
         clearCart()
         navigate("/");
-        window.open(`https://wa.me/${phone}?text=${msg}`, "_blank"); */
+        window.open(`https://wa.me/${phone}?text=${msg}`, "_blank");
 
         // Elimina el método de pago guardado al enviar el pedido
         localStorage.removeItem(PAYMENT_METHOD_KEY);

--- a/src/components/ShopMenu.jsx
+++ b/src/components/ShopMenu.jsx
@@ -55,14 +55,14 @@ const ShopMenu = () => {
     getShopDetails(setShop, setCategories, tag_shop);
   }, [tag_shop]);
 
-  const [selectedCombo, setSelectedCombo] = useState(null);
+  const [selectedFood, setSelectedFood] = useState(null);
 
-  const handleComboClick = (item) => {
-    setSelectedCombo(item);
+  const handleFoodClick = (item) => {
+    setSelectedFood(item);
   };
 
   const handleCloseModal = () => {
-    setSelectedCombo(null);
+    setSelectedFood(null);
   };
 
   //Carousel filtering
@@ -222,7 +222,7 @@ const ShopMenu = () => {
                             <ItemCard
                               key={item.id}
                               item={item}
-                              onItemClick={handleComboClick}
+                              onItemClick={handleFoodClick}
                             />
                           ))}
                         </div>
@@ -233,7 +233,7 @@ const ShopMenu = () => {
                             <li
                               key={item.id}
                               className="flex justify-between items-start gap-2 p-4 bg-white rounded-xl shadow"
-                              onClick={() => handleComboClick(item)}
+                              onClick={() => handleFoodClick(item)}
                             >
                               {/* info */}
                               <article className="flex-1 pr-2 flex flex-col gap-y-1">
@@ -272,15 +272,15 @@ const ShopMenu = () => {
             )}
           </div>
         </main>
-        {selectedCombo && (
+        {selectedFood && (
           <FoodDetailsModal
-            combo={{ ...selectedCombo, shop: shop }}
+            food={{ ...selectedFood, shop: shop }}
             onClose={handleCloseModal}
           />
         )}
       </section>
 
-      {shopCartItems.length > 0 && !selectedCombo && (
+      {shopCartItems.length > 0 && !selectedFood && (
         <footer className="fixed bottom-0 sm:right-5 w-full sm:w-auto bg-white sm:size-m sm:rounded-md shadow-orange-700 shadow-2xl z-50">
           <div className="max-w-6xl mx-auto flex items-center justify-between px-3 sm:px-4 sm:gap-x-6 py-3">
             <div>

--- a/src/components/ShoppingCart.jsx
+++ b/src/components/ShoppingCart.jsx
@@ -210,7 +210,7 @@ const ShoppingCart = () => {
                                             <span className="font-semibold sm:text-lg">{group.shopInfo.name}</span>?
                                         </div>
 
-                                        <div className="flex justify-between items-center flex-col sm:flex-row w-full sm:w-auto gap-3">
+                                        <div className="flex justify-between items-center flex-col sm:flex-row-reverse w-full sm:w-auto gap-3">
                                             <button
                                                 onClick={() =>
                                                     handlePlaceOrder(group.shopInfo, group.items)

--- a/src/services/getAdditionals.js
+++ b/src/services/getAdditionals.js
@@ -1,8 +1,10 @@
 import api from '../lib/api';
 
-const getAdditionals = async (setAdditionals, shop_id) => {
+const getAdditionals = async (setAdditionals, category_id) => {
   try {
-    const response = await api.get(`/products/additions?shop_id=${shop_id}`);
+    const response = await api.get(
+      `/products/additions?category_id=${category_id}`
+    );
     if (response.status === 200) {
       const additionals = response.data;
       setAdditionals(additionals);

--- a/src/services/getFlovors.js
+++ b/src/services/getFlovors.js
@@ -1,0 +1,16 @@
+import api from '../lib/api';
+
+const getFlovors = async (setFlovors, item_id) => {
+  try {
+    const response = await api.get(`/products/flavors?item_id=${item_id}`);
+
+    if (response.status === 200) {
+      setFlovors(response.data);
+      return;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export default getFlovors;

--- a/src/services/getShops.js
+++ b/src/services/getShops.js
@@ -7,7 +7,7 @@ const getAllShops = async (setShops) => {
   showLoader();
   try {
     //requests
-    const response = await api.get('/api/shops/all');
+    const response = await api.get('/shops/all');
     //add shops
     if (response.status === 200) {
       const shops = response.data;

--- a/src/services/sendOrders.js
+++ b/src/services/sendOrders.js
@@ -2,7 +2,7 @@ import api from '../lib/api';
 
 const sendOrders = async (data) => {
   try {
-    await api.post(data);
+    await api.post('/orders', data);
   } finally {
     return;
   }


### PR DESCRIPTION
Se introduce la funcionalidad para que los usuarios puedan seleccionar sabores en productos que lo permitan (ej. pizzas de dos sabores).

- Se crea un nuevo servicio `getFlavors.js` para obtener los sabores disponibles para un producto específico.
- Se modifica `FoodDetailsModal.jsx` para mostrar la sección de "Sabores" si el producto tiene la propiedad `has_flavors`.
- Se implementa la lógica de selección basada en las reglas del producto (`max_flavors` y `selector_type`), permitiendo selecciones únicas o múltiples.
- Se añade un botón "Quitar selección" para mejorar la usabilidad.
- Se actualizan los componentes `ShoppingCart.jsx` y `CheckoutShopping.jsx` para mostrar los sabores seleccionados en el resumen del pedido.
- Se ajusta el servicio `sendOrders.js` para incluir los sabores en el payload del pedido que se envía al servidor.