### PR TITLE
feat: Refactoriza cálculo de subtotales para items multi-sabor

### DIFF
--- a/src/components/FoodDetailsModal.jsx
+++ b/src/components/FoodDetailsModal.jsx
@@ -16,6 +16,9 @@ const FoodDetailsModal = ({ food, onClose }) => {
   const [observation, setObservation] = useState("");
   const [quantity, setQuantity] = useState(1);
   const [flavors, setFlavors] = useState([]);
+  const [selectFlavorsError, setSelectdFlavorsError] = useState("")
+
+  console.log(food)
 
   const { addItem } = useCartStore();
   const navigate = useNavigate();
@@ -60,10 +63,6 @@ const FoodDetailsModal = ({ food, onClose }) => {
     };
   }, [onClose]);
 
-  const unitPrice =
-    food.price + selectedAdditionals.reduce((sum, a) => sum + (a.price || 0), 0);
-  const total = unitPrice * quantity;
-
   const flavorRules = useMemo(() => {
     if (!food.rules || !Array.isArray(food.rules)) return {};
     const rule = food.rules.find((r) => r.rule_key === "max_flavors");
@@ -72,6 +71,27 @@ const FoodDetailsModal = ({ food, onClose }) => {
       selectorType: rule ? rule.selector_type : "single_select",
     };
   }, [food.rules]);
+
+  const totalSelectedFlavors = useMemo(() => {
+    // Para multi_select, suma las cantidades. Para single_select, cuenta los items.
+    return selectedFlavors.reduce((sum, f) => sum + (f.quantity || 1), 0);
+  }, [selectedFlavors]);
+
+  const { total, finalQuantity } = useMemo(() => {
+    const additionalsPrice = selectedAdditionals.reduce((sum, a) => sum + (a.price || 0), 0);
+
+    if (flavorRules.selectorType === 'multi_select') {
+      // Para multi_select, la cantidad es el total de sabores y el precio se multiplica.
+      const flavorsTotal = food.price * totalSelectedFlavors;
+      // Los adicionales se suman al final, no se multiplican por cantidad de sabores.
+      return { total: flavorsTotal + additionalsPrice, finalQuantity: totalSelectedFlavors };
+    }
+
+    // Para productos normales y single_select, se usa el contador de cantidad.
+    const unitPrice = food.price + additionalsPrice;
+    return { total: unitPrice * quantity, finalQuantity: quantity };
+
+  }, [food.price, selectedAdditionals, totalSelectedFlavors, flavorRules.selectorType, quantity]);
 
   const handleFlavorClick = (flavor) => {
     setSelectedFlavors((prev) => {
@@ -94,18 +114,48 @@ const FoodDetailsModal = ({ food, onClose }) => {
     });
   };
 
+  const handleFlavorQuantityChange = (flavor, change) => {
+    setSelectedFlavors(prev => {
+      const existingFlavor = prev.find(f => f.id === flavor.id);
+      const currentTotal = prev.reduce((sum, f) => sum + f.quantity, 0);
+
+      // Si se quiere añadir y ya se alcanzó el límite
+      if (change > 0 && currentTotal >= flavorRules.maxFlavors) {
+        return prev;
+      }
+
+      if (existingFlavor) {
+        const newQuantity = existingFlavor.quantity + change;
+        if (newQuantity > 0) {
+          // Actualizar cantidad
+          return prev.map(f => f.id === flavor.id ? { ...f, quantity: newQuantity } : f);
+        } else {
+          // Eliminar si la cantidad es 0
+          return prev.filter(f => f.id !== flavor.id);
+        }
+      } else if (change > 0) {
+        // Añadir nuevo sabor con cantidad 1
+        return [...prev, { ...flavor, quantity: 1 }];
+      }
+
+      return prev; // No hacer nada si se intenta restar de un sabor no seleccionado
+    });
+  };
+
   const handleAddToCart = () => {
     // Validación para sabores si son obligatorios
-    if (food.has_flavors && flavorRules.maxFlavors > 0 && selectedFlavors.length === 0) {
-      alert(`Debes seleccionar al menos un sabor.`);
+    if (flavorRules.selectorType === 'multi_select' && totalSelectedFlavors === 0) {
+      setSelectdFlavorsError(`Debes seleccionar al menos un sabor.`);
       return;
     }
+
+    setSelectdFlavorsError(''); // Limpiar error si pasa la validación
     addItem({
       ...food,
       additionals: selectedAdditionals,
       flavors: selectedFlavors,
       observation: observation.trim(),
-      quantity,
+      quantity: finalQuantity,
       price: food.price,
       shopInfo: food.shop,
     });
@@ -122,73 +172,52 @@ const FoodDetailsModal = ({ food, onClose }) => {
       className="fixed w-full h-full inset-0 bg-black bg-opacity-50 flex z-50 sm:flex sm:items-center sm:justify-center"
       onClick={onClose}
     >
-      <aside
-        className="bg-white w-full h-full flex flex-col sm:w-2/5 sm:h-3/4 sm:rounded-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* header */}
+      <aside className="bg-white w-full h-full flex flex-col sm:w-2/5 sm:h-[90vh] sm:max-h-[800px] sm:rounded-xl" onClick={(e) => e.stopPropagation()}>
+        {/* Header con imagen (solo móvil) y botón de cerrar */}
         <header className="relative shrink-0 ">
-          <img
-            src={food.image}
-            alt={food.name}
-            className="w-full h-64 object-cover sm:rounded-t-xl"
-          />
-
-          {/* logo */}
-          {
-            validateShopPath ?
-              <div className="absolute top-4 left-4" onClick={() => navigate(`/${food.shop.tag}`)}>
-                <img src={food.shop.logo_image} alt={food.shop.logo_image} className="size-16 object-cover rounded-full border-2 border-orange-200 hover:border-orange-500 cursor-pointer transition-colors" />
-
-              </div>
-              : null
-          }
           <button
             onClick={onClose}
-            className="absolute top-4 right-4 bg-white/80 hover:bg-white rounded-full p-2 transition-all duration-300 hidden sm:inline-block"
+            className="absolute top-4 right-4 bg-white/80 hover:bg-white rounded-full p-2 transition-all duration-300 z-10"
           >
             <X className="w-6 h-6 text-gray-800" />
           </button>
+          <img src={food.image} alt={food.name} className="w-full h-64 object-cover sm:hidden" />
         </header>
 
-        {/* details */}
-        <section className="flex-1 overflow-y-auto p-6">
-          <div className="flex justify-between items-center flex-wrap mb-2">
-            <h2 className="text-3xl font-bold text-gray-900 mb-2">{food.name}</h2>
-            <h4 className="text-3xl sm:text-4xl font-extrabold text-orange-600">
-              ${total.toLocaleString()}
-            </h4>
+        {/* Header Fijo con Nombre y Precio */}
+        <div className="shrink-0 p-6 border-b border-gray-200">
+          <div className="flex justify-between items-start flex-wrap">
+            <div className="flex items-center gap-x-3">
+              <h2 className="text-3xl font-bold text-gray-900">{food.name}</h2>
+              {flavorRules.selectorType === 'multi_select' && (
+                <span className="text-xl font-semibold text-gray-500 bg-gray-100 px-3 py-1 rounded-lg">
+                  ${food.price.toLocaleString()} c/u
+                </span>
+              )}
+            </div>
+            {flavorRules.selectorType !== 'multi_select' && (
+              <h4 className="text-3xl sm:text-4xl font-extrabold text-orange-600">${total.toLocaleString()}</h4>
+            )}
           </div>
+        </div>
+
+        {/* Contenido Principal (Scrollable) */}
+        <section className="flex-1 overflow-y-auto p-6">
+          <img src={food.image} alt={food.name} className="w-full h-64 object-cover rounded-xl mb-4 hidden sm:block" />
           <p className="text-lg text-gray-600 mt-1">{food.description}</p>
 
-          {/* cantidad */}
-          <div className="mt-6 flex items-center space-x-4">
-            <p className="text-lg sm:text-xl font-semibold">Cantidad</p>
-            <button
-              onClick={() => setQuantity((q) => (q > 1 ? q - 1 : 1))}
-              className="bg-gray-200 hover:bg-gray-300 p-2 rounded-full"
-            >
-              <Minus className="size-5" />
-            </button>
-            <span className="text-xl font-bold">{quantity}</span>
-            <button
-              onClick={() => setQuantity((q) => q + 1)}
-              className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-full"
-            >
-              <Plus className="w-5 h-5" />
-            </button>
-          </div>
-
           {/* observaciones */}
-          <div className="mt-4">
-            <label className="block text-gray-950 mb-2 sm:text-xl text-lg">Observaciones</label>
-            <textarea
-              className="w-full border border-gray-400 rounded-lg p-3 text-gray-800 focus:ring-2 focus:ring-orange-400"
-              rows="2"
-              value={observation}
-              onChange={(e) => setObservation(e.target.value)}
-            />
-          </div>
+          {flavorRules.selectorType !== 'multi_select' && (
+            <div className="mt-4">
+              <label className="block text-gray-950 mb-2 sm:text-xl text-lg">Observaciones</label>
+              <textarea
+                className="w-full border border-gray-400 rounded-lg p-3 text-gray-800 focus:ring-2 focus:ring-orange-400"
+                rows="2"
+                value={observation}
+                onChange={(e) => setObservation(e.target.value)}
+              />
+            </div>
+          )}
 
           {/* sabores */}
           {food.has_flavors && flavors.length > 0 && (
@@ -197,7 +226,7 @@ const FoodDetailsModal = ({ food, onClose }) => {
                 <h3 className="text-lg sm:text-xl font-semibold">
                   Sabores
                   <span className="text-base font-normal text-gray-600 ml-2">
-                    (Elige hasta {flavorRules.maxFlavors})
+                    ({flavorRules.selectorType === 'multi_select' ? `Total: ${totalSelectedFlavors} de ${flavorRules.maxFlavors}` : `Elige hasta ${flavorRules.maxFlavors}`})
                   </span>
                 </h3>
                 {selectedFlavors.length > 0 && (
@@ -209,24 +238,46 @@ const FoodDetailsModal = ({ food, onClose }) => {
                   </button>
                 )}
               </div>
+              {selectFlavorsError && (
+                <p className="text-red-600 my-2">{selectFlavorsError}</p>
+              )}
               <div className="flex flex-col gap-2">
-                {flavors.map((flavor) => (
-                  <button
-                    key={flavor.id}
-                    onClick={() => handleFlavorClick(flavor)}
-                    disabled={
-                      selectedFlavors.length >= flavorRules.maxFlavors &&
-                      !selectedFlavors.find((f) => f.id === flavor.id)
-                    }
-                    className={`w-full flex justify-between items-center border rounded-lg px-4 py-3 text-base sm:text-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${selectedFlavors.find((f) => f.id === flavor.id)
-                      ? "bg-orange-500 text-white border-orange-600 shadow-md"
-                      : "bg-orange-50 hover:bg-orange-100 border-orange-200"
-                      }`}
-                  >
-                    <span className="text-left">{flavor.name}</span>
-                    {/* El precio de los sabores no se suma, es para elegir */}
-                  </button>
-                ))}
+                {flavorRules.selectorType === 'multi_select'
+                  ? flavors.map((flavor) => {
+                    const selected = selectedFlavors.find(f => f.id === flavor.id);
+                    const currentQty = selected ? selected.quantity : 0;
+                    return (
+                      <div key={flavor.id} className="w-full flex justify-between items-center border rounded-lg px-4 py-2 text-base sm:text-lg bg-orange-50 border-orange-200">
+                        <span className="text-left">{flavor.name}</span>
+                        <div className="flex items-center gap-3">
+                          <button onClick={() => handleFlavorQuantityChange(flavor, -1)} disabled={currentQty === 0} className="bg-gray-200 hover:bg-gray-300 p-2 rounded-full disabled:opacity-50">
+                            <Minus className="size-4" />
+                          </button>
+                          <span className="text-xl font-bold w-6 text-center">{currentQty}</span>
+                          <button onClick={() => handleFlavorQuantityChange(flavor, 1)} disabled={totalSelectedFlavors >= flavorRules.maxFlavors} className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-full disabled:opacity-50">
+                            <Plus className="size-4" />
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  })
+                  : flavors.map((flavor) => (
+                    <button
+                      key={flavor.id}
+                      onClick={() => handleFlavorClick(flavor)}
+                      disabled={
+                        selectedFlavors.length >= flavorRules.maxFlavors &&
+                        !selectedFlavors.find((f) => f.id === flavor.id)
+                      }
+                      className={`w-full flex justify-between items-center border rounded-lg px-4 py-3 text-base sm:text-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${selectedFlavors.find((f) => f.id === flavor.id)
+                        ? "bg-orange-500 text-white border-orange-600 shadow-md"
+                        : "bg-orange-50 hover:bg-orange-100 border-orange-200"
+                        }`}
+                    >
+                      <span className="text-left">{flavor.name}</span>
+                    </button>
+                  ))
+                }
               </div>
             </div>
           )}
@@ -262,25 +313,38 @@ const FoodDetailsModal = ({ food, onClose }) => {
               : null
           }
 
-
-          {/* footer */}
-          <footer className="shrink-0 flex flex-col items-center mt-5 gap-5">
-            <div className="flex justify-between sm:justify-end w-full gap-2">
-              <button
-                onClick={onClose}
-                className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-6 rounded-lg transition-colors inline-block sm:hidden"
-              >
-                Cerrar
-              </button>
-              <button
-                onClick={handleAddToCart}
-                className="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-6 rounded-lg transition-colors"
-              >
-                Agregar al Carrito
-              </button>
-            </div>
-          </footer>
         </section>
+
+        {/* Footer Fijo con Contador y Botón */}
+        <footer className="shrink-0 p-6 border-t border-gray-200 bg-white">
+          <div className="flex justify-between items-center w-full gap-4">
+            {/* Contador de Cantidad (si aplica) */}
+            {flavorRules.selectorType !== 'multi_select' ? (
+              <div className="flex items-center space-x-3">
+                <button onClick={() => setQuantity((q) => (q > 1 ? q - 1 : 1))} className="bg-gray-200 hover:bg-gray-300 p-2 rounded-full">
+                  <Minus className="size-5" />
+                </button>
+                <span className="text-xl font-bold w-8 text-center">{quantity}</span>
+                <button onClick={() => setQuantity((q) => q + 1)} className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-full">
+                  <Plus className="w-5 h-5" />
+                </button>
+              </div>
+            ) : (
+              // Muestra el total de sabores para multi_select
+              <div className="flex flex-col">
+                <span className="text-gray-600 text-lg">Total</span>
+                <span className="text-2xl font-extrabold text-orange-600">
+                  ${(food.price * totalSelectedFlavors).toLocaleString()}
+                </span>
+              </div>
+            )}
+
+            {/* Botón de Agregar */}
+            <button onClick={handleAddToCart} className="flex-1 sm:flex-none sm:w-64 bg-orange-500 hover:bg-orange-600 text-white font-bold py-3 px-6 rounded-lg transition-colors text-lg">
+              Agregar
+            </button>
+          </div>
+        </footer>
       </aside>
     </dialog>
   );

--- a/src/components/ShopMenu.jsx
+++ b/src/components/ShopMenu.jsx
@@ -33,12 +33,18 @@ const ShopMenu = () => {
   const { cart } = useCartStore();
   const { formatNumber } = useNumberFormat();
   const shopCartItems = cart.filter(item => item.shopInfo?.id === shop.id);
+
   const shopTotal = shopCartItems.reduce((sum, item) => {
-    const additionalsTotal = (item.additionals || []).reduce(
-      (addSum, additional) => addSum + (additional.price || 0),
-      0
-    );
-    return sum + (item.price + additionalsTotal) * item.quantity;
+    const isMultiSelect = item.rules?.some(r => r.rule_key === 'max_flavors' && r.selector_type === 'multi_select');
+    const flavorCount = item.flavors?.reduce((sum, f) => sum + (f.quantity || 1), 0) || 0;
+    const quantity = isMultiSelect && flavorCount > 0 ? flavorCount : item.quantity || 1;
+
+    const additionalsPricePerUnit = (item.additionals || []).reduce((addSum, additional) => addSum + (additional.price || 0), 0);
+
+    const subtotal = isMultiSelect
+      ? (item.price * quantity) + additionalsPricePerUnit
+      : (item.price + additionalsPricePerUnit) * quantity;
+    return sum + subtotal;
   }, 0);
 
   const totalItems = shopCartItems.reduce(


### PR DESCRIPTION
Se ha refactorizado la lógica para calcular los subtotales de los productos en el carrito de compras, especialmente para aquellos con selección múltiple de sabores (`multi_select`).

Anteriormente, el precio de los adicionales se multiplicaba incorrectamente por la cantidad de sabores en lugar de sumarse una sola vez al total del producto.

Cambios realizados:
- **FoodDetailsModal:** Se ajustó el cálculo del precio total para que los adicionales se sumen una sola vez en productos `multi_select`.
- **ShoppingCart:** Se corrigió la función `preprocessCartItems` para calcular correctamente el subtotal, sumando los adicionales una vez para `multi_select` y multiplicándolos por la cantidad para otros productos. Se mejoró la visualización del desglose de precios.
- **CheckoutShopping:** Se unificó la lógica de pre-procesamiento para ser consistente con el carrito de compras.
- **cartUtils:** Se actualizó la función `buildWhatsAppMessage` para reflejar el cálculo de precios correcto en el mensaje de pedido.
- **ShopMenu:** Se corrigió el cálculo del total del carrito que se muestra en el pie de página del menú de la tienda.